### PR TITLE
New funciton `get_corners_radius()`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,17 @@ local insets, status = safearea.get_insets()
 -- The amount of "unsafe" space against each edge of the screen, in pixels
 print(insets.top, insets.right, insets.bottom, insets.left)
 
+-- Android 12.0+ only
+local corners, status = safearea.get_corners_radius()
+
+-- The radius for rounded corners of the device screen
+print(corners.bottom_left, corners.bottom_right, corners.top_left, corners.top_right)
+-- Calculate offset based on radius
+for key, value in pairs(corners) do
+    local offset = value * math.sin(math.rad(45))
+    print("Offset "..key.." : "..offset)
+end
+
 -- iOS only
 safearea.set_background_color(vmath.vector4(0,0,0,0))
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ local corners, status = safearea.get_corners_radius()
 -- The radius for rounded corners of the device screen
 print(corners.bottom_left, corners.bottom_right, corners.top_left, corners.top_right)
 -- Calculate offset based on radius
+-- https://developer.android.com/develop/ui/views/layout/insets/rounded-corners
 for key, value in pairs(corners) do
     local offset = value * math.sin(math.rad(45))
     print("Offset "..key.." : "..offset)

--- a/main/main.script
+++ b/main/main.script
@@ -24,6 +24,7 @@ function update(self)
         if self.safearea_status == safearea.STATUS_OK then
             pprint("SAFE_AREA in update:", self.safearea)
             pprint("CORNERS in update:", self.corners)
+            -- https://developer.android.com/develop/ui/views/layout/insets/rounded-corners
             for key, value in pairs(self.corners) do
                 local offset = value * math.sin(math.rad(45))
                 print("Offset "..key.." : "..offset)

--- a/main/main.script
+++ b/main/main.script
@@ -18,9 +18,16 @@ function update(self)
         self.update_counter = self.update_counter + 1
         print("Update:", self.update_counter)
         self.safearea, self.safearea_status = safearea.get_insets()
-        print("Status:", self.safearea_status)
+        self.corners, self.corners_status = safearea.get_corners_radius()
+        print("Safearea Status:", self.safearea_status)
+        print("Corners Status:", self.corners_status)
         if self.safearea_status == safearea.STATUS_OK then
             pprint("SAFE_AREA in update:", self.safearea)
+            pprint("CORNERS in update:", self.corners)
+            for key, value in pairs(self.corners) do
+                local offset = value * math.sin(math.rad(45))
+                print("Offset "..key.." : "..offset)
+            end
         end
     end
 end

--- a/safearea/api/safearea.script_api
+++ b/safearea/api/safearea.script_api
@@ -27,6 +27,15 @@
           type: table
 
 #*****************************************************************************************************
+    - name: get_corners_radius
+      type: function
+      desc: returns a table with `top_left`, `top_right`, `bottom_left`, and `bottom_right` values of rounded corners and status.
+      
+      returns:
+        - name: corners
+          type: table
+
+#*****************************************************************************************************
 
     - name: STATUS_OK
       type: number

--- a/safearea/src/safearea.cpp
+++ b/safearea/src/safearea.cpp
@@ -36,6 +36,34 @@ static int GetInsets(lua_State* L)
     return 2;
 }
 
+static int GetCornersRadius(lua_State* L)
+{
+    DM_LUA_STACK_CHECK(L, 2);
+
+    safeareans::Corners corners = {
+        .bottom_left = 0.0f,
+        .bottom_right = 0.0f,
+        .top_left = 0.0f,
+        .top_right = 0.0f,
+    };
+
+    safeareans::SafeAreaStatus status = safeareans::GetCornersRadius(&corners);
+
+    lua_newtable(L);
+    lua_pushnumber(L, corners.bottom_left);
+    lua_setfield(L, -2, "bottom_left");
+    lua_pushnumber(L, corners.bottom_right);
+    lua_setfield(L, -2, "bottom_right");
+    lua_pushnumber(L, corners.top_left);
+    lua_setfield(L, -2, "top_left");
+    lua_pushnumber(L, corners.top_right);
+    lua_setfield(L, -2, "top_right");
+
+    lua_pushnumber(L, status);
+
+    return 2;
+}
+
 static int SetBackgroundColor(lua_State* L)
 {
     DM_LUA_STACK_CHECK(L, 0);
@@ -50,6 +78,7 @@ static int SetBackgroundColor(lua_State* L)
 static const luaL_reg SafeArea_methods[] =
 {   
     {"get_insets", GetInsets},
+    {"get_corners_radius", GetCornersRadius},
     {"set_background_color", SetBackgroundColor},
     {0, 0}
 };

--- a/safearea/src/safearea.h
+++ b/safearea/src/safearea.h
@@ -12,7 +12,12 @@ namespace safeareans
         float bottom, left, right, top;
     };
 
+    struct Corners {
+        float bottom_left, bottom_right, top_left, top_right;
+    };
+
     void ResizeGameView(float* bg_color);
     SafeAreaStatus GetInsets(Insets* insets);
+    SafeAreaStatus GetCornersRadius(Corners* corners);
     void SetBackgroundColor(float x, float y, float z, float w);
 }

--- a/safearea/src/safearea_android.cpp
+++ b/safearea/src/safearea_android.cpp
@@ -50,5 +50,66 @@ SafeAreaStatus GetInsets(Insets* insets)
     return STATUS_OK;
 }
 
+SafeAreaStatus GetCornersRadius(Corners* corners)
+{
+    // API is avaliable on Android 12+ (API 31+)
+    if (android_get_device_api_level() < 31)
+    {
+        return STATUS_NOT_AVAILABLE;
+    }
+
+    ThreadAttacher attacher;
+    JNIEnv *env = attacher.env;
+    ClassLoader class_loader = ClassLoader(env);
+
+    jclass cls = class_loader.load("android/app/Activity");
+    jobject jwindow = env->CallObjectMethod(dmGraphics::GetNativeAndroidActivity(), env->GetMethodID(cls, "getWindow", "()Landroid/view/Window;"));
+
+    cls = class_loader.load("android/view/Window");
+    jobject jdecorView = env->CallObjectMethod(jwindow, env->GetMethodID(cls, "getDecorView", "()Landroid/view/View;"));
+
+    cls = class_loader.load("android/view/View");
+    jobject jinsets = env->CallObjectMethod(jdecorView, env->GetMethodID(cls, "getRootWindowInsets", "()Landroid/view/WindowInsets;"));
+
+    cls = class_loader.load("android/view/WindowInsets");
+    jobject cutouts = env->CallObjectMethod(jinsets, env->GetMethodID(cls, "getDisplayCutout", "()Landroid/view/DisplayCutout;"));
+
+    if (!cutouts)
+    {
+        return STATUS_NOT_READY_YET;
+    }
+
+    jclass roundedCornerClass = class_loader.load("android/view/RoundedCorner");
+    jmethodID getRoundedCornerMethodID = env->GetMethodID(cls, "getRoundedCorner", "(I)Landroid/view/RoundedCorner;");
+    jmethodID getRadiusMethodID = env->GetMethodID(roundedCornerClass, "getRadius", "()I");
+
+    jint POSITION_TOP_LEFT = 0;
+    jint POSITION_TOP_RIGHT = 1;
+    jint POSITION_BOTTOM_RIGHT = 2;
+    jint POSITION_BOTTOM_LEFT = 3;
+
+    jobject topLeftCorner = env->CallObjectMethod(jinsets, getRoundedCornerMethodID, POSITION_TOP_LEFT);
+    if (topLeftCorner) {
+        corners->top_left = env->CallIntMethod(topLeftCorner, getRadiusMethodID);
+    }
+
+    jobject topRightCorner = env->CallObjectMethod(jinsets, getRoundedCornerMethodID, POSITION_TOP_RIGHT);
+    if (topRightCorner) {
+        corners->top_right = env->CallIntMethod(topRightCorner, getRadiusMethodID);
+    }
+
+    jobject bottomLeftCorner = env->CallObjectMethod(jinsets, getRoundedCornerMethodID, POSITION_BOTTOM_LEFT);
+    if (bottomLeftCorner) {
+        corners->bottom_left = env->CallIntMethod(bottomLeftCorner, getRadiusMethodID);
+    }
+
+    jobject bottomRightCorner = env->CallObjectMethod(jinsets, getRoundedCornerMethodID, POSITION_BOTTOM_RIGHT);
+    if (bottomRightCorner) {
+        corners->bottom_right = env->CallIntMethod(bottomRightCorner, getRadiusMethodID);
+    }
+    
+    return STATUS_OK;
+}
+
 } // namespace
 #endif // DM_PLATFORM_ANDROID

--- a/safearea/src/safearea_ios.mm
+++ b/safearea/src/safearea_ios.mm
@@ -49,6 +49,10 @@ safeareans::SafeAreaStatus safeareans::GetInsets(Insets* insets) {
     return STATUS_OK;
 }
 
+safeareans::SafeAreaStatus safeareans::GetCornersRadius(Corners* corners){
+    return STATUS_NOT_AVAILABLE;
+}
+
 void safeareans::SetBackgroundColor(float x, float y, float z, float w) 
 {
     UIView* glview = (UIView*)dmGraphics::GetNativeiOSUIView();

--- a/safearea/src/safearea_null.cpp
+++ b/safearea/src/safearea_null.cpp
@@ -12,4 +12,8 @@ safeareans::SafeAreaStatus safeareans::GetInsets(Insets* insets) {
     return STATUS_NOT_AVAILABLE;
 }
 
+SafeAreaStatus safeareans::GetCornersRadius(Corners* corners){
+    return STATUS_NOT_AVAILABLE;
+}
+
 #endif // !defined(DM_PLATFORM_IOS) && !defined(DM_PLATFORM_ANDROID)


### PR DESCRIPTION
New function `safearea.get_corners_radius()` returns the radius for rounded corners of the device screen. It's available only on Android 12.0+

Question raised here: https://forum.defold.com/t/how-to-check-if-a-node-is-blocked-by-a-rounded-screen-corner/77405